### PR TITLE
Use PEP 508 URL format for charm-crypto dependency

### DIFF
--- a/.ci/travis-after-success.sh
+++ b/.ci/travis-after-success.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 if [ "${BUILD}" == "tests" ]; then
     codecov
 fi

--- a/.ci/travis-before-install.sh
+++ b/.ci/travis-before-install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 if [ "${BUILD}" != "flake8" ]; then
     apt-get update -qq
     apt-get -y install flex bison libgmp-dev libmpc-dev python-dev libssl-dev

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 pip install --upgrade pip
 
 # will not be needed for flake8

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -4,10 +4,12 @@ set -e -x
 
 pip install --upgrade pip
 
-# will not be needed for flake8
-git clone https://github.com/JHUISI/charm.git
-cd charm && ./configure.sh && make install
-cd ..
+if [ "${BUILD}" != "flake8" ]; then
+    pip install --upgrade setuptools
+    git clone https://github.com/JHUISI/charm.git
+    cd charm && ./configure.sh && make install
+    cd ..
+fi
 
 if [ "${BUILD}" == "tests" ]; then
     pip install -e .[test]

--- a/.ci/travis-script.sh
+++ b/.ci/travis-script.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 if [ "${BUILD}" == "tests" ]; then
     pytest -v --cov=honeybadgerbft
 elif [ "${BUILD}" == "flake8" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-python: 3.6
+sudo: required
+dist: xenial
+python: 3.7
 
 env:
   global:

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR $SRC
 ADD . $SRC/
 
 RUN pip install --upgrade pip
-RUN pip install --process-dependency-links -e .[dev]
+RUN pip install -e .[dev]
 
 # Run tests by default
 CMD sh test.sh

--- a/honeybadgerbft/core/honeybadger.py
+++ b/honeybadgerbft/core/honeybadger.py
@@ -44,7 +44,7 @@ def broadcast_receiver_loop(recv_func, recv_queues):
 
 
 class HoneyBadgerBFT():
-    """HoneyBadgerBFT object used to run the protocol.
+    r"""HoneyBadgerBFT object used to run the protocol.
 
     :param str sid: The base name of the common coin that will be used to
         derive a nonce to uniquely identify the coin.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ install_requires = [
     'ecdsa',
     'zfec>=1.5.0',
     'gipc',
-    'charm-crypto @ https://github.com/JHUISI/charm.git@dev',
     'coincurve',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'ecdsa',
     'zfec>=1.5.0',
     'gipc',
-    'charm-crypto>=0.50',
+    'charm-crypto @ https://github.com/JHUISI/charm.git@dev',
     'coincurve',
 ]
 
@@ -81,7 +81,4 @@ setup(
         'dev': dev_require + tests_require + docs_require,
         'docs': docs_require,
     },
-    dependency_links=[
-        'git+https://github.com/JHUISI/charm.git@dev#egg=0.50',
-    ],
 )


### PR DESCRIPTION
The pip option `--process-dependency-links` is no longer supported.